### PR TITLE
Versatile paging

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,6 @@ dotnet_diagnostic.IDE0160.severity = none
 
 # IDE0130: Namespace does not match folder structure
 dotnet_diagnostic.IDE0130.severity = none
+
+# IDE0290: Use primary constructor
+dotnet_diagnostic.IDE0290.severity = none

--- a/src/BitzArt.Pagination.EntityFrameworkCore/ToPageAsyncExtension.cs
+++ b/src/BitzArt.Pagination.EntityFrameworkCore/ToPageAsyncExtension.cs
@@ -17,19 +17,21 @@ public static class ToPageAsyncExtension
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     /// <exception cref="ArgumentException">Offset is null or Limit is null.</exception>
-    public static Task<PageResult<T>> ToPageAsync<T>(this IQueryable<T> query, int offset, int limit, CancellationToken cancellationToken = default)
+    public static Task<PageResult<T, PageRequest>> ToPageAsync<T>(this IQueryable<T> query, int offset, int limit, CancellationToken cancellationToken = default)
         => query.ToPageAsync(new PageRequest(offset, limit), cancellationToken);
 
     /// <summary>
     /// Converts a query to a page of items
     /// </summary>
-    /// <typeparam name="T">The item type.</typeparam>
+    /// <typeparam name="T">Item type.</typeparam>
+    /// <typeparam name="TRequest">Page request type.</typeparam>
     /// <param name="query">The dataset to build the page from.</param>
     /// <param name="request">Page request.</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     /// <exception cref="ArgumentException">Offset is null or Limit is null.</exception>
-    public static async Task<PageResult<T>> ToPageAsync<T>(this IQueryable<T> query, IPageRequest request, CancellationToken cancellationToken = default)
+    public static async Task<PageResult<T, TRequest>> ToPageAsync<T, TRequest>(this IQueryable<T> query, TRequest request, CancellationToken cancellationToken = default)
+        where TRequest : IPageRequest
     {
         var data = await request
             .ApplyConstraints(query)
@@ -37,6 +39,6 @@ public static class ToPageAsyncExtension
 
         var total = await query.CountAsync(cancellationToken);
 
-        return new PageResult<T>(data, request, total);
+        return new PageResult<T, TRequest>(data, request, total);
     }
 }

--- a/src/BitzArt.Pagination.EntityFrameworkCore/ToPageAsyncExtension.cs
+++ b/src/BitzArt.Pagination.EntityFrameworkCore/ToPageAsyncExtension.cs
@@ -29,14 +29,10 @@ public static class ToPageAsyncExtension
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     /// <exception cref="ArgumentException">Offset is null or Limit is null.</exception>
-    public static async Task<PageResult<T>> ToPageAsync<T>(this IQueryable<T> query, PageRequest request, CancellationToken cancellationToken = default)
+    public static async Task<PageResult<T>> ToPageAsync<T>(this IQueryable<T> query, IPageRequest request, CancellationToken cancellationToken = default)
     {
-        if (request.Offset is null) throw new ArgumentException("Offset is null");
-        if (request.Limit is null) throw new ArgumentException("Limit is null");
-
-        var data = await query
-            .Skip(request.Offset.Value)
-            .Take(request.Limit.Value)
+        var data = await request
+            .ApplyConstraints(query)
             .ToListAsync(cancellationToken);
 
         var total = await query.CountAsync(cancellationToken);

--- a/src/BitzArt.Pagination/Extensions/ConvertExtension.cs
+++ b/src/BitzArt.Pagination/Extensions/ConvertExtension.cs
@@ -8,9 +8,10 @@ public static class ConvertExtension
     /// <summary>
     /// Converts the Data of a PageResult using a selector
     /// </summary>
-    public static PageResult<TResult> Convert<TSource, TResult>(this PageResult<TSource> source, Func<TSource, TResult> selector)
+    public static PageResult<TResult, TRequest> Convert<TSource, TRequest, TResult>(this PageResult<TSource, TRequest> initial, Func<TSource, TResult> selector)
+        where TRequest : IPageRequest
     {
-        var data = source.Items!.Select(selector);
-        return new PageResult<TResult>(data, source.Request, source.Total);
+        var data = initial.Items!.Select(selector);
+        return new PageResult<TResult, TRequest>(data, initial.Request, initial.Total);
     }
 }

--- a/src/BitzArt.Pagination/Extensions/ToPageExtension.cs
+++ b/src/BitzArt.Pagination/Extensions/ToPageExtension.cs
@@ -7,14 +7,10 @@ namespace System.Linq;
 /// </summary>
 public static class ToPageExtension
 {
-    /// <summary>
-    /// Converts a query to a page of items
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="query">Dataset to build the page from</param>
-    /// <param name="offset">Requested page offset</param>
-    /// <param name="limit">Requested page limit</param>
-    /// <returns>A <see cref="PageResult{T}"/> containing the requested items</returns>
+    /// <inheritdoc cref="ToPage{T}(IEnumerable{T}, IPageRequest)"/>
+    /// <param name="query">Dataset to build the page from.</param>
+    /// <param name="offset">Requested page offset.</param>
+    /// <param name="limit">Requested page limit.</param>
     public static PageResult<T> ToPage<T>(this IEnumerable<T> query, int offset, int limit)
         => query.ToPage(new PageRequest(offset, limit));
 
@@ -22,15 +18,12 @@ public static class ToPageExtension
     /// Converts a query to a page of items
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    /// <param name="query">Dataset to build the page from</param>
-    /// <param name="request">Page request</param>
+    /// <param name="query">Dataset to build the page from.</param>
+    /// <param name="request">Page request.</param>
     /// <returns>A <see cref="PageResult{T}"/> containing the requested items</returns>
-    public static PageResult<T> ToPage<T>(this IEnumerable<T> query, PageRequest request)
+    public static PageResult<T> ToPage<T>(this IEnumerable<T> query, IPageRequest request)
     {
-        if (request.Offset is null) throw new ArgumentException("Offset is null");
-        if (request.Limit is null) throw new ArgumentException("Limit is null");
-
-        var data = query.Skip(request.Offset.Value).Take(request.Limit.Value);
+        var data = request.ApplyConstraints(query);
         var total = query.Count();
 
         return new PageResult<T>(data, request, total);

--- a/src/BitzArt.Pagination/Extensions/ToPageExtension.cs
+++ b/src/BitzArt.Pagination/Extensions/ToPageExtension.cs
@@ -7,25 +7,27 @@ namespace System.Linq;
 /// </summary>
 public static class ToPageExtension
 {
-    /// <inheritdoc cref="ToPage{T}(IEnumerable{T}, IPageRequest)"/>
+    /// <inheritdoc cref="ToPage{T,TRequest}(IEnumerable{T}, TRequest)"/>
     /// <param name="query">Dataset to build the page from.</param>
     /// <param name="offset">Requested page offset.</param>
     /// <param name="limit">Requested page limit.</param>
-    public static PageResult<T> ToPage<T>(this IEnumerable<T> query, int offset, int limit)
+    public static PageResult<T, PageRequest> ToPage<T>(this IEnumerable<T> query, int offset, int limit)
         => query.ToPage(new PageRequest(offset, limit));
 
     /// <summary>
     /// Converts a query to a page of items
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">Item type.</typeparam>
+    /// <typeparam name="TRequest">Page request type.</typeparam>
     /// <param name="query">Dataset to build the page from.</param>
     /// <param name="request">Page request.</param>
     /// <returns>A <see cref="PageResult{T}"/> containing the requested items</returns>
-    public static PageResult<T> ToPage<T>(this IEnumerable<T> query, IPageRequest request)
+    public static PageResult<T, TRequest> ToPage<T, TRequest>(this IEnumerable<T> query, TRequest request)
+        where TRequest : IPageRequest
     {
         var data = request.ApplyConstraints(query);
         var total = query.Count();
 
-        return new PageResult<T>(data, request, total);
+        return new PageResult<T, TRequest>(data, request, total);
     }
 }

--- a/src/BitzArt.Pagination/Interfaces/IPageRequest.cs
+++ b/src/BitzArt.Pagination/Interfaces/IPageRequest.cs
@@ -1,0 +1,18 @@
+﻿namespace BitzArt.Pagination;
+
+/// <summary>
+/// A request for a page of items.
+/// </summary>
+public interface IPageRequest
+{
+    /// <summary>
+    /// Method used to apply constraints specified in the request to a query.
+    /// </summary>
+    /// <typeparam name="TSource">Type of the items in the query.</typeparam>
+    /// <param name="query">Original query.</param>
+    /// <returns>A query with constraints applied.</returns>
+    public IEnumerable<TSource> ApplyConstraints<TSource>(IEnumerable<TSource> query);
+
+    /// <inheritdoc cref="ApplyConstraints{TSource}(IEnumerable{TSource})"/>
+    public IQueryable<TSource> ApplyConstraints<TSource>(IQueryable<TSource> query);
+}

--- a/src/BitzArt.Pagination/Models/PageRequest.cs
+++ b/src/BitzArt.Pagination/Models/PageRequest.cs
@@ -43,4 +43,10 @@ public class PageRequest : IPageRequest
     /// <inheritdoc/>
     public IQueryable<TSource> ApplyConstraints<TSource>(IQueryable<TSource> query)
         => query.Skip(Offset).Take(Limit);
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        return $"Offset: {Offset}, Limit: {Limit}";
+    }
 }

--- a/src/BitzArt.Pagination/Models/PageRequest.cs
+++ b/src/BitzArt.Pagination/Models/PageRequest.cs
@@ -3,21 +3,22 @@
 namespace BitzArt.Pagination;
 
 /// <summary>
-/// A request for a page of items
+/// A request for a page of items.
 /// </summary>
-public class PageRequest
+public class PageRequest : IPageRequest
 {
     /// <summary>
-    /// Requested page offset
+    /// Requested page offset.
     /// </summary>
     [JsonPropertyName("offset")]
-    public virtual int? Offset { get; set; }
+    public int Offset { get; set; }
 
     /// <summary>
-    /// Requested page limit
+    /// Requested page limit.
     /// </summary>
     [JsonPropertyName("limit")]
-    public virtual int? Limit { get; set; }
+    public int Limit { get; set; }
+
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PageRequest"/> class.
@@ -29,9 +30,17 @@ public class PageRequest
     /// </summary>
     /// <param name="offset">Requested page offset</param>
     /// <param name="limit">Requested page limit</param>
-    public PageRequest(int? offset, int? limit)
+    public PageRequest(int offset, int limit)
     {
         Offset = offset;
         Limit = limit;
     }
+
+    /// <inheritdoc/>
+    public IEnumerable<TSource> ApplyConstraints<TSource>(IEnumerable<TSource> query)
+        => query.Skip(Offset).Take(Limit);
+
+    /// <inheritdoc/>
+    public IQueryable<TSource> ApplyConstraints<TSource>(IQueryable<TSource> query)
+        => query.Skip(Offset).Take(Limit);
 }

--- a/src/BitzArt.Pagination/Models/PageResult.cs
+++ b/src/BitzArt.Pagination/Models/PageResult.cs
@@ -1,92 +1,16 @@
-﻿using System.Text.Json.Serialization;
+﻿namespace BitzArt.Pagination;
 
-namespace BitzArt.Pagination;
-
-/// <summary>
-/// A page of items
-/// </summary>
+/// <inheritdoc/>
 public class PageResult : PageResult<object>
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="PageResult{T}"/> class.
-    /// </summary>
-    /// <param name="items">Page items</param>
-    /// <param name="offset">Requested page offset</param>
-    /// <param name="limit">Requested page limit</param>
-    /// <param name="total">Total number of items available</param>
-    public PageResult(IEnumerable<object>? items, int? offset, int? limit, int? total)
+    /// <inheritdoc cref="PageResult{T}(IEnumerable{T},int,int,int?)"/>"
+    public PageResult(IEnumerable<object>? items, int offset, int limit, int? total)
         : this(items, new PageRequest(offset, limit), total) { }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="PageResult{T}"/> class.
-    /// </summary>
-    /// <param name="items">Page items</param>
-    /// <param name="request">Page request used to generate this page</param>
-    /// <param name="total">Total number of items available</param>
-    public PageResult(IEnumerable<object>? items, PageRequest? request, int? total) : base(items, request, total) { }
+    /// <inheritdoc/>
+    public PageResult(IEnumerable<object>? items, IPageRequest? request, int? total)
+        : base(items, request, total) { }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="PageResult"/> class.
-    /// </summary>
-    public PageResult() : base() { }
-}
-
-/// <summary>
-/// A page of items
-/// </summary>
-/// <typeparam name="T">Item type</typeparam>
-public class PageResult<T>
-{
-    /// <summary>
-    /// The request used to generate this page
-    /// </summary>
-    [JsonPropertyName("request")]
-    public PageRequest? Request { get; set; }
-
-    /// <summary>
-    /// The number of items in this page
-    /// </summary>
-    [JsonPropertyName("count")]
-    public int? Count { get; set; }
-
-    /// <summary>
-    /// The total number of items available
-    /// </summary>
-    [JsonPropertyName("total")]
-    public int? Total { get; set; }
-
-    /// <summary>
-    /// The items in this page
-    /// </summary>
-    [JsonPropertyName("items")]
-    public IEnumerable<T>? Items { get; set; }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="PageResult{T}"/> class.
-    /// </summary>
-    /// <param name="items">Page items</param>
-    /// <param name="offset">Requested page offset</param>
-    /// <param name="limit">Requested page limit</param>
-    /// <param name="total">Total number of items available</param>
-    public PageResult(IEnumerable<T> items, int? offset, int? limit, int? total)
-        : this(items, new PageRequest(offset, limit), total) { }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="PageResult{T}"/> class.
-    /// </summary>
-    /// <param name="items">Page items</param>
-    /// <param name="request">Page request used to generate this page</param>
-    /// <param name="total">Total number of items available</param>
-    public PageResult(IEnumerable<T>? items, PageRequest? request, int? total) : this()
-    {
-        Items = items;
-        Count = items?.Count();
-        Request = request;
-        Total = total;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="PageResult{T}"/> class.
-    /// </summary>
+    /// <inheritdoc/>
     public PageResult() : base() { }
 }

--- a/src/BitzArt.Pagination/Models/PageResult/1.PageResult{T,TRequest}.cs
+++ b/src/BitzArt.Pagination/Models/PageResult/1.PageResult{T,TRequest}.cs
@@ -6,13 +6,15 @@ namespace BitzArt.Pagination;
 /// A page of items.
 /// </summary>
 /// <typeparam name="T">Item type.</typeparam>
-public class PageResult<T>
+/// <typeparam name="TRequest">Page request type.</typeparam>
+public class PageResult<T, TRequest>
+    where TRequest : IPageRequest
 {
     /// <summary>
     /// The request used to generate this page.
     /// </summary>
     [JsonPropertyName("request")]
-    public IPageRequest? Request { get; set; }
+    public TRequest? Request { get; set; }
 
     /// <summary>
     /// The number of items in this page.
@@ -33,22 +35,12 @@ public class PageResult<T>
     public IEnumerable<T>? Items { get; set; }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="PageResult{T}"/> class.
-    /// </summary>
-    /// <param name="items">Page items.</param>
-    /// <param name="offset">Requested page offset.</param>
-    /// <param name="limit">Requested page limit.</param>
-    /// <param name="total">Total number of items available.</param>
-    public PageResult(IEnumerable<T> items, int offset, int limit, int? total)
-        : this(items, new PageRequest(offset, limit), total) { }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="PageResult{T}"/> class.
+    /// Initializes a new instance of the <see cref="PageResult{T,TPageRequest}"/> class.
     /// </summary>
     /// <param name="items">Page items.</param>
     /// <param name="request">The request used to generate this page.</param>
     /// <param name="total">Total number of items available.</param>
-    public PageResult(IEnumerable<T>? items, IPageRequest? request, int? total) : this()
+    public PageResult(IEnumerable<T>? items, TRequest? request, int? total) : this()
     {
         Items = items;
         Count = items?.Count();
@@ -57,7 +49,7 @@ public class PageResult<T>
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="PageResult{T}"/> class.
+    /// Initializes a new instance of the <see cref="PageResult{T,TPageRequest}"/> class.
     /// </summary>
     public PageResult() { }
 }

--- a/src/BitzArt.Pagination/Models/PageResult/2.PageResult{T}.cs
+++ b/src/BitzArt.Pagination/Models/PageResult/2.PageResult{T}.cs
@@ -1,0 +1,34 @@
+﻿namespace BitzArt.Pagination;
+
+/// <inheritdoc/>
+public class PageResult<T> : PageResult<T, PageRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PageResult{T,TPageRequest}"/> class.
+    /// </summary>
+    /// <param name="items">Page items.</param>
+    /// <param name="offset">Requested page offset.</param>
+    /// <param name="limit">Requested page limit.</param>
+    /// <param name="total">Total number of items available.</param>
+    public PageResult(IEnumerable<T> items, int offset, int limit, int? total)
+        : base(items, new PageRequest(offset, limit), total) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PageResult{T,TPageRequest}"/> class.
+    /// </summary>
+    /// <param name="items">Page items.</param>
+    /// <param name="request">The request used to generate this page.</param>
+    /// <param name="total">Total number of items available.</param>
+    public PageResult(IEnumerable<T>? items, PageRequest? request, int? total) : this()
+    {
+        Items = items;
+        Count = items?.Count();
+        Request = request;
+        Total = total;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PageResult{T,TPageRequest}"/> class.
+    /// </summary>
+    public PageResult() { }
+}

--- a/src/BitzArt.Pagination/Models/PageResult/3.PageResult.cs
+++ b/src/BitzArt.Pagination/Models/PageResult/3.PageResult.cs
@@ -8,7 +8,7 @@ public class PageResult : PageResult<object>
         : this(items, new PageRequest(offset, limit), total) { }
 
     /// <inheritdoc/>
-    public PageResult(IEnumerable<object>? items, IPageRequest? request, int? total)
+    public PageResult(IEnumerable<object>? items, PageRequest? request, int? total)
         : base(items, request, total) { }
 
     /// <inheritdoc/>

--- a/src/BitzArt.Pagination/Models/PageResult{T}.cs
+++ b/src/BitzArt.Pagination/Models/PageResult{T}.cs
@@ -1,0 +1,63 @@
+﻿using System.Text.Json.Serialization;
+
+namespace BitzArt.Pagination;
+
+/// <summary>
+/// A page of items.
+/// </summary>
+/// <typeparam name="T">Item type.</typeparam>
+public class PageResult<T>
+{
+    /// <summary>
+    /// The request used to generate this page.
+    /// </summary>
+    [JsonPropertyName("request")]
+    public IPageRequest? Request { get; set; }
+
+    /// <summary>
+    /// The number of items in this page.
+    /// </summary>
+    [JsonPropertyName("count")]
+    public int? Count { get; set; }
+
+    /// <summary>
+    /// The total number of items available.
+    /// </summary>
+    [JsonPropertyName("total")]
+    public int? Total { get; set; }
+
+    /// <summary>
+    /// The items in this page.
+    /// </summary>
+    [JsonPropertyName("items")]
+    public IEnumerable<T>? Items { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PageResult{T}"/> class.
+    /// </summary>
+    /// <param name="items">Page items.</param>
+    /// <param name="offset">Requested page offset.</param>
+    /// <param name="limit">Requested page limit.</param>
+    /// <param name="total">Total number of items available.</param>
+    public PageResult(IEnumerable<T> items, int offset, int limit, int? total)
+        : this(items, new PageRequest(offset, limit), total) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PageResult{T}"/> class.
+    /// </summary>
+    /// <param name="items">Page items.</param>
+    /// <param name="request">The request used to generate this page.</param>
+    /// <param name="total">Total number of items available.</param>
+    public PageResult(IEnumerable<T>? items, IPageRequest? request, int? total) : this()
+    {
+        Items = items;
+        Count = items?.Count();
+        Request = request;
+        Total = total;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PageResult{T}"/> class.
+    /// </summary>
+    public PageResult() { }
+}

--- a/tests/BitzArt.Pagination.Tests/ConvertTests.cs
+++ b/tests/BitzArt.Pagination.Tests/ConvertTests.cs
@@ -8,14 +8,19 @@ public class ConvertTests
 {
     [Theory]
     [InlineData(10)]
-    public void ToPage_CorrectSource_CorrectResult(int count)
+    [InlineData(100)]
+    public void Convert_OnGoodSource_ShouldReturnCorrectResult(int count)
     {
+        // Arrange
         var sourceData = new List<TestSourceClass>();
         for (int i = 0; i < count; i++) sourceData.Add(new TestSourceClass($"test object {i + 1}"));
 
         var sourcePage = sourceData.ToPage(0, count);
+
+        // Act
         var resultPage = sourcePage.Convert(x => x.ToResult());
 
+        // Assert
         for (int i = 0; i < count; i++)
         {
             var source = sourcePage.Items.ElementAt(i);

--- a/tests/BitzArt.Pagination.Tests/ConvertTests.cs
+++ b/tests/BitzArt.Pagination.Tests/ConvertTests.cs
@@ -1,52 +1,50 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
-namespace BitzArt.Pagination.Tests
+namespace BitzArt.Pagination.Tests;
+
+public class ConvertTests
 {
-    public class ConvertTests
+    [Theory]
+    [InlineData(10)]
+    public void ToPage_CorrectSource_CorrectResult(int count)
     {
-        [Theory]
-        [InlineData(10)]
-        public void ToPage_CorrectSource_CorrectResult(int count)
+        var sourceData = new List<TestSourceClass>();
+        for (int i = 0; i < count; i++) sourceData.Add(new TestSourceClass($"test object {i + 1}"));
+
+        var sourcePage = sourceData.ToPage(0, count);
+        var resultPage = sourcePage.Convert(x => x.ToResult());
+
+        for (int i = 0; i < count; i++)
         {
-            var sourceData = new List<TestSourceClass>();
-            for (int i = 0; i < count; i++) sourceData.Add(new TestSourceClass($"test object {i + 1}"));
+            var source = sourcePage.Items.ElementAt(i);
+            var result = resultPage.Items.ElementAt(i);
 
-            var sourcePage = sourceData.ToPage(0, count);
-            var resultPage = sourcePage.Convert(x => x.ToResult());
+            Assert.Equal(source, result.Source);
+            Assert.Equal(source.Name, result.Source.Name);
+        }
+    }
 
-            for (int i = 0; i < count; i++)
-            {
-                var source = sourcePage.Items.ElementAt(i);
-                var result = resultPage.Items.ElementAt(i);
+    private class TestSourceClass
+    {
+        public string Name { get; set; }
 
-                Assert.Equal(source, result.Source);
-                Assert.Equal(source.Name, result.Source.Name);
-            }
+        public TestSourceClass(string name)
+        {
+            Name = name;
         }
 
-        private class TestSourceClass
+        public TestResultClass ToResult() => new(this);
+    }
+
+    private class TestResultClass
+    {
+        public TestSourceClass Source;
+
+        public TestResultClass(TestSourceClass source)
         {
-            public string Name { get; set; }
-
-            public TestSourceClass(string name)
-            {
-                Name = name;
-            }
-
-            public TestResultClass ToResult() => new(this);
-        }
-
-        private class TestResultClass
-        {
-            public TestSourceClass Source;
-
-            public TestResultClass(TestSourceClass source)
-            {
-                Source = source;
-            }
+            Source = source;
         }
     }
 }

--- a/tests/BitzArt.Pagination.Tests/PageRequestTests.cs
+++ b/tests/BitzArt.Pagination.Tests/PageRequestTests.cs
@@ -1,0 +1,46 @@
+﻿using System.Linq;
+using Xunit;
+
+namespace BitzArt.Pagination.Tests;
+
+public class PageRequestTests
+{
+    [Theory]
+    [InlineData(100, 0, 10)]
+    [InlineData(100, 0, 100)]
+    [InlineData(100, 10, 10)]
+    [InlineData(100, 90, 10)]
+    public void ApplyConstraints_WithinBoundaries_ShouldFilterCorrectly(int total, int offset, int limit)
+    {
+        // Arrange
+        var list = Enumerable.Range(1, total);
+        var request = new PageRequest(offset, limit);
+
+        // Act
+        var result = request.ApplyConstraints(list);
+
+        // Assert
+        Assert.Equal(list.Skip(offset).Take(limit), result);
+    }
+
+    [Theory]
+    [InlineData(10, 9, 2)]
+    [InlineData(10, 5, 10)]
+    [InlineData(100, 50, 100)]
+    [InlineData(100, 90, 100)]
+    [InlineData(100, 100, 100)]
+    [InlineData(0, 10, 10)]
+    [InlineData(0, 0, 0)]
+    public void ApplyConstraints_CrossingOrOutOfBoundaries_ShouldFilterCorrectly(int total, int offset, int limit)
+    {
+        // Arrange
+        var list = Enumerable.Range(1, total);
+        var request = new PageRequest(offset, limit);
+
+        // Act
+        var result = request.ApplyConstraints(list);
+
+        // Assert
+        Assert.Equal(list.Skip(offset).Take(limit), result);
+    }
+}

--- a/tests/BitzArt.Pagination.Tests/SerializationTests.cs
+++ b/tests/BitzArt.Pagination.Tests/SerializationTests.cs
@@ -1,0 +1,35 @@
+﻿using System.Linq;
+using System.Text.Json;
+using Xunit;
+
+namespace BitzArt.Pagination;
+
+public class SerializationTests
+{
+    [Theory]
+    [InlineData(0, 0, 0)]
+    [InlineData(0, 0, 1)]
+    [InlineData(0, 1, 0)]
+    [InlineData(0, 1, 1)]
+    [InlineData(10, 0, 10)]
+    [InlineData(100, 0, 10)]
+    [InlineData(10, 10, 10)]
+    public void SerializeAndDeserialize_PageResult_ShouldRemainTheSame(int total, int offset, int limit)
+    {
+        // Arrange
+        var data = Enumerable.Range(1, total);
+        var page = data.ToPage(offset, limit);
+        var json = JsonSerializer.Serialize(page);
+
+        // Act
+        var result = JsonSerializer.Deserialize<PageResult<int>>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(page.Items, result.Items);
+        Assert.Equal(page.Request.Offset, result.Request.Offset);
+        Assert.Equal(page.Request.Limit, result.Request.Limit);
+        Assert.Equal(page.Total, result.Total);
+        Assert.Equal(page.Count, result.Count);
+    }
+}

--- a/tests/BitzArt.Pagination.Tests/ToPageTests.cs
+++ b/tests/BitzArt.Pagination.Tests/ToPageTests.cs
@@ -1,30 +1,74 @@
+using System;
 using System.Linq;
 using Xunit;
 
-namespace BitzArt.Pagination.Tests
+namespace BitzArt.Pagination.Tests;
+
+public class ToPageTests
 {
-    public class ToPageTests
+    [Theory]
+    [InlineData(0, 10)]
+    [InlineData(10, 10)]
+    [InlineData(10, 0)]
+    [InlineData(0, 0)]
+    [InlineData(0, 100)]
+    [InlineData(0, 1000)]
+    [InlineData(1000, 1000)]
+    public void ToPage_OnEnumerable_ShouldHaveCorrectPageRequest(int offset, int limit)
     {
-        [Theory]
-        [InlineData(100, 0, 10)]
-        [InlineData(100, 10, 10)]
-        [InlineData(10, 0, 10)]
-        [InlineData(0, 0, 1)]
-        [InlineData(0, 1, 1)]
-        [InlineData(0, 1, 0)]
-        public void ToPage_OnIEnumerable_CorrectResult(int total, int offset, int limit)
-        {
-            var list = Enumerable.Range(1, total);
-            var result = list.ToPage(offset, limit);
+        // Arrange
+        var list = Enumerable.Range(1, 100);
 
-            Assert.Equal(total, result.Total);
-            Assert.Equal(offset, result.Request.Offset);
-            Assert.Equal(limit, result.Request.Limit);
-            Assert.Equal(result.Items.Count(), result.Count);
+        // Act
+        var result = list.ToPage(offset, limit);
 
-            if (result.Count == 0) return;
+        // Assert
+        Assert.IsType<PageRequest>(result.Request);
+        var pageRequest = (PageRequest)result.Request;
 
-            Assert.Equal(list.ElementAt(offset), result.Items.First());
-        }
+        Assert.Equal(offset, pageRequest.Offset);
+        Assert.Equal(limit, pageRequest.Limit);
+    }
+
+    [Theory]
+    [InlineData(100, 0, 10)]
+    [InlineData(100, 10, 10)]
+    [InlineData(10, 0, 10)]
+    [InlineData(0, 0, 1)]
+    [InlineData(0, 1, 1)]
+    [InlineData(0, 1, 0)]
+    public void ToPage_OnEnumerable_ShouldApplyConstraints(int total, int offset, int limit)
+    {
+        // Arrange
+        var list = Enumerable.Range(1, total);
+        var request = new PageRequest(offset, limit);
+
+        var expectedItems = request.ApplyConstraints(list);
+
+        // Act
+        var result = list.ToPage(offset, limit);
+
+        // Assert
+        Assert.Equal(expectedItems, result.Items);
+    }
+
+    [Theory]
+    [InlineData(100, 0, 10)]
+    [InlineData(100, 10, 10)]
+    [InlineData(10, 0, 10)]
+    [InlineData(0, 0, 1)]
+    [InlineData(0, 1, 1)]
+    [InlineData(0, 1, 0)]
+    public void ToPage_OnEnumerable_TotalShouldBeCorrect(int total, int offset, int limit)
+    {
+        // Arrange
+        var list = Enumerable.Range(1, total);
+
+        // Act
+        var result = list.ToPage(offset, limit);
+
+        // Assert
+        Assert.Equal(result.Items.Count(), result.Count);
+        Assert.Equal(total, result.Total);
     }
 }


### PR DESCRIPTION
Extracted interface `IPageRequest` for additional versatility - the package now allows custom pagination schemes (e.g. `Offset+Limit`, `PageNumber+PageSize`, `Cursor-based`, etc.) and no longer enforces the default implementation of PageRequest class.

Custom pagination schemes can be accomplished by implementing IPageRequest interface and passing the resulting object to `ToPage`/`ToPageAsync` method.

Since the default `PageRequest` class is no longer enforced, deserialization of the resulting `PageResult` should be done something like the following:

```csharp
var myDeserializedPageResult = JsonSerializer.Deserialize<PageResult<T, MyPageRequest>>(myJson);
// where MyPageRequest is your PageRequest implementation
```

If `TRequest` is not specified when deserializing (or any other operation for that matter), the default `PageRequest` class will be used.