### PR TITLE
Allow null limit but still use default if not specified

### DIFF
--- a/src/BitzArt.Pagination/Models/PageRequest.cs
+++ b/src/BitzArt.Pagination/Models/PageRequest.cs
@@ -8,29 +8,28 @@ namespace BitzArt.Pagination;
 public class PageRequest : IPageRequest
 {
     /// <summary>
+    /// Default limit if not specified in the request.
+    /// </summary>
+    protected virtual int DefaultLimit => 100;
+
+    /// <summary>
     /// Requested page offset.
     /// </summary>
     [JsonPropertyName("offset")]
-    public int Offset { get; set; }
+    public int? Offset { get; set; }
 
     /// <summary>
     /// Requested page limit.
     /// </summary>
     [JsonPropertyName("limit")]
-    public int Limit { get; set; }
-
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="PageRequest"/> class.
-    /// </summary>
-    public PageRequest() : this(0, 100) { }
+    public int? Limit { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PageRequest"/> class.
     /// </summary>
     /// <param name="offset">Requested page offset</param>
     /// <param name="limit">Requested page limit</param>
-    public PageRequest(int offset, int limit)
+    public PageRequest(int? offset = null, int? limit = null)
     {
         Offset = offset;
         Limit = limit;
@@ -38,11 +37,33 @@ public class PageRequest : IPageRequest
 
     /// <inheritdoc/>
     public IEnumerable<TSource> ApplyConstraints<TSource>(IEnumerable<TSource> query)
-        => query.Skip(Offset).Take(Limit);
+    {
+        if (Offset is not null)
+        {
+            query = query.Skip(Offset!.Value);
+        }
+
+        query = Limit is not null
+            ? query.Take(Limit!.Value)
+            : query.Take(DefaultLimit);
+
+        return query;
+    }
 
     /// <inheritdoc/>
     public IQueryable<TSource> ApplyConstraints<TSource>(IQueryable<TSource> query)
-        => query.Skip(Offset).Take(Limit);
+    {
+        if (Offset is not null)
+        {
+            query = query.Skip(Offset!.Value);
+        }
+
+        query = Limit is not null
+            ? query.Take(Limit!.Value)
+            : query.Take(DefaultLimit);
+
+        return query;
+    }
 
     /// <inheritdoc/>
     public override string ToString()

--- a/src/BitzArt.Pagination/Models/PageRequest.cs
+++ b/src/BitzArt.Pagination/Models/PageRequest.cs
@@ -27,8 +27,8 @@ public class PageRequest : IPageRequest
     /// <summary>
     /// Initializes a new instance of the <see cref="PageRequest"/> class.
     /// </summary>
-    /// <param name="offset">Requested page offset</param>
-    /// <param name="limit">Requested page limit</param>
+    /// <param name="offset">Requested page offset. If <c>null</c>, defaults to <c>0</c>.</param>
+    /// <param name="limit">Requested page limit. If <c>null</c>, defaults to <see cref="DefaultLimit"/>.</param>
     public PageRequest(int? offset = null, int? limit = null)
     {
         Offset = offset;

--- a/src/BitzArt.Pagination/Models/PageRequest.cs
+++ b/src/BitzArt.Pagination/Models/PageRequest.cs
@@ -27,8 +27,8 @@ public class PageRequest : IPageRequest
     /// <summary>
     /// Initializes a new instance of the <see cref="PageRequest"/> class.
     /// </summary>
-    /// <param name="offset">Requested page offset. If <c>null</c>, defaults to <c>0</c>.</param>
-    /// <param name="limit">Requested page limit. If <c>null</c>, defaults to <see cref="DefaultLimit"/>.</param>
+    /// <param name="offset">Requested page offset. If <see langword="null"/>, defaults to <c>0</c>.</param>
+    /// <param name="limit">Requested page limit. If <see langword="null"/>, defaults to <see cref="DefaultLimit"/>.</param>
     public PageRequest(int? offset = null, int? limit = null)
     {
         Offset = offset;


### PR DESCRIPTION
This pull request refactors the `PageRequest` class in the `BitzArt.Pagination` namespace to improve flexibility and handle null values for pagination parameters. The changes include introducing a default limit, making `Offset` and `Limit` nullable, and updating constraint application logic.

### Enhancements to `PageRequest`:

* **Default Limit Added**: Introduced a protected virtual property `DefaultLimit` with a value of 100, which is used when the `Limit` is not specified. (`src/BitzArt.Pagination/Models/PageRequest.cs`, [src/BitzArt.Pagination/Models/PageRequest.csR10-R66](diffhunk://#diff-70fd972e888c0da39a20e99abbcf9620276307577879afa9769e4bf69d9995d7R10-R66))
* **Nullable Pagination Parameters**: Changed the `Offset` and `Limit` properties to nullable (`int?`) to allow for more flexible handling of pagination parameters. (`src/BitzArt.Pagination/Models/PageRequest.cs`, [src/BitzArt.Pagination/Models/PageRequest.csR10-R66](diffhunk://#diff-70fd972e888c0da39a20e99abbcf9620276307577879afa9769e4bf69d9995d7R10-R66))
* **Updated Constructor**: Modified the constructor to accept optional nullable parameters for `offset` and `limit`, defaulting to `null` when not provided. (`src/BitzArt.Pagination/Models/PageRequest.cs`, [src/BitzArt.Pagination/Models/PageRequest.csR10-R66](diffhunk://#diff-70fd972e888c0da39a20e99abbcf9620276307577879afa9769e4bf69d9995d7R10-R66))
* **Improved Constraint Application**: Refactored the `ApplyConstraints` methods for both `IEnumerable` and `IQueryable` to handle null values for `Offset` and `Limit`, and to use `DefaultLimit` when `Limit` is not provided. (`src/BitzArt.Pagination/Models/Page